### PR TITLE
Adds support for batching requests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,22 +4,54 @@ var cachestore = new Eidetic({
   canPutWhenFull: true
 });
 
+var queues = {};
+
 module.exports.cacheSeconds = function(ttl) {
 
   return function(req, res, next) {
-
+    var self = this;
     var cache = cachestore.get(req.path);
+    //var send = res.send;
+    res.original_send = res.send;
 
+    // returns the value immediately
     if (cache) {
       res.send(cache);
-    } else {
-      var send = res.send;
-      res.send = function(string) {
+      return;
+    }
+
+    if (!queues[req.path]) {
+      queues[req.path] = [];
+    }
+
+    // first request will get rendered output
+    if (queues[req.path].length === 0
+      && queues[req.path].push(function noop(){})) {
+
+      res.send = function (string) {
         var body = string instanceof Buffer ? string.toString() : string;
         cachestore.put(req.url, body, ttl);
-        send.call(this, body);
+        
+        // drain the queue so anyone else waiting for
+        // this value will get their responses.
+        var subscriber = null;
+        while (subscriber = queues[req.path].shift()) {
+          if (subscriber) {
+            process.nextTick(subscriber);
+          }
+        }
+        res.original_send(body);
       };
+
       next();
+    // subsequent requests will batch while the first computes
+    } else {
+      queues[req.path].push(function() {
+        var body = cachestore.get(req.path);
+        res.send(body);
+      });
     }
+
   }
+
 };


### PR DESCRIPTION
@bradoyler Previously, route-cache would allow a big burst of requests to flow into the handler, resulting in a bunch of identical calls to hbs render. This change lets the first one slip in, and batches up each subsequent request until the render completes. As soon as the render is complete, the queued up batch of requests is drained. From the moment the request comes back, a new cache value should be available, which prevents new requests from getting queued up while the queue is drained. So far, I have seen about ~280% increase in requests per second.
