### PR TITLE
adds EventEmitter and constructor for cachestore setup

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,29 @@
 
+/* globals - should, describe, it */
 var request = require('supertest'),
-    should = require('should'),
-    routeCache = require('../index'),
+    RouteCache = require('../index'),
     express = require('express');
 
- var app = express(); 
+ var app = express();
  var testindex = 0;
+ var routeCache = new RouteCache();
+
+ routeCache.on('cache.get', function(key) {
+   console.log('cache.get for key: ', key);
+ });
+ routeCache.on('cache.set', function(key) {
+   console.log('cache.set for key: ', key);
+ });
 
 describe('# RouteCache middleware test', function(){
-  var app = express();
 
   app.get('/hello', routeCache.cacheSeconds(1), function(req, res){
   	 testindex++;
-     res.send('Hello ' + testindex)
+     res.send('Hello ' + testindex);
+  });
+
+  app.get('/test', routeCache.cacheSeconds(25), function(req, res){
+    res.send('test');
   });
 
   var agent = request.agent(app);
@@ -21,19 +32,19 @@ describe('# RouteCache middleware test', function(){
     agent
     .get('/hello')
     .expect('Hello 1', done);
-  })
- 
+  });
+
   it('GET #2: Hello 1', function(done){
     agent
     .get('/hello')
     .expect('Hello 1', done);
-  })
+  });
 
   it('GET #3: Hello 1', function(done){
     agent
     .get('/hello')
     .expect('Hello 1', done);
-  })
+  });
 
   it('GET #4 ~ delayed: Hello 2', function(done){
   	setTimeout(function() {
@@ -41,5 +52,5 @@ describe('# RouteCache middleware test', function(){
 	    .get('/hello')
 	    .expect('Hello 2', done);
     }, 1200);
-  })
-})
+  });
+});


### PR DESCRIPTION
For #7 
- prep for redis support
- updates tests
#### breaking change:

now requires constructor ie. 

``` javascript
var RouteCache = require('route-cache');
var routeCache = new RouteCache();
```
