### PR TITLE
upgrade eidetic dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Brad Oyler <bradoyler@gmail.com> (github.com/bradoyler)",
   "license": "MIT",
   "dependencies": {
-    "eidetic": "0.1.1"
+    "eidetic": "^0.3.1"
   },
   "devDependencies": {
     "mocha": "~1.13.0",


### PR DESCRIPTION
I've been experiencing an issue where the eidetic@0.1.1's underscore dependency causes my application to crash on load because a global for `root` isn't defined. Upgrading eidetic to 0.3.1 fixes this thanks to that version dropping the underscore dependency all together. Tests still pass. 