### PR TITLE
add support for dynamic cacheKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,33 @@ npm test
 
 ## How to use
 ```javascript
-
 var routeCache = require('route-cache');
 
 // cache route for 20 seconds
 app.get('/index', routeCache.cacheSeconds(20), function(req, res){
-	// do your dirty work here...
-	console.log('you will only see this every 20 seconds.');
-	res.send('this response will be cached');
+  // do your dirty work here...
+  console.log('you will only see this every 20 seconds.');
+  res.send('this response will be cached');
 });
-
-
 ```
+
+By default `req.originalUrl` is used as the cache key so every URL is cached separately.
+
+You can set a custom key by passing a second argument to `cacheSeconds`.
+
+```javascript
+routeCache.cacheSeconds(20, 'my-custom-cache-key')
+```
+
+You can set a dynamic key from the `req` and `res` objects by passing a function.
+
+```javascript
+// Cache authenticated and unauthenticated responses separately
+routeCache.cacheSeconds(20, function(req, res) {
+  return req.originalUrl + '|' + res.locals.signedIn
+})
+```
+
 
 ## Delete a cached route
 ```javascript

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ module.exports.config = function (opts) {
 module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
   var ttl = secondsTTL * 1000
   return function (req, res, next) {
-    var key = req.originalUrl
+    var key = req.originalUrl // default cache key
     if (typeof cacheKey === 'function') {
-      key = cacheKey(req, res)
+      key = cacheKey(req, res) // dynamic key
     } else if (typeof cacheKey === 'string') {
-      key = cacheKey
+      key = cacheKey // custom key
     }
 
     if (redirects[key]) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,13 @@ module.exports.config = function (opts) {
 module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
   var ttl = secondsTTL * 1000
   return function (req, res, next) {
-    var key = (cacheKey === undefined) ? req.originalUrl : cacheKey
+    var key = req.originalUrl
+    if (typeof cacheKey === 'function') {
+      key = cacheKey(req, res)
+    } else if (typeof cacheKey === 'string') {
+      key = cacheKey
+    }
+
     if (redirects[key]) {
       return res.redirect(redirects[key].status, redirects[key].url)
     }
@@ -53,8 +59,6 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
     var didHandle = false
 
     function rawSend (data, isJson) {
-      var key = (cacheKey === undefined) ? req.originalUrl : cacheKey
-
       // pass-through for Buffer - not supported
       if (typeof data === 'object') {
         if (Buffer.isBuffer(data)) {

--- a/test/cacheKey.js
+++ b/test/cacheKey.js
@@ -1,0 +1,43 @@
+'use strict'
+var request = require('supertest'),
+  routeCache = require('../index'),
+  express = require('express'),
+  assert = require('assert')
+
+var hitIndex = 0
+
+var app = express()
+
+function getCacheKey(req, res) {
+  return req.url + '|cookie=' + req.headers.cookie
+}
+
+app.get('/hello/dynamicCacheKey', routeCache.cacheSeconds(1, getCacheKey), function (req, res) {
+  hitIndex++
+  res.send('Hello dynamicCacheKey#' + hitIndex)
+})
+
+var agent = request.agent(app)
+
+describe('cacheKey as a callback', function () {
+  it('1st dynamic cacheKey', function (done) {
+    agent
+      .get('/hello/dynamicCacheKey')
+      .set('Cookie', 'cookie=yep')
+      .expect('Hello dynamicCacheKey#1', done)
+  })
+
+  it('2st dynamic cacheKey', function (done) {
+    agent
+      .get('/hello/dynamicCacheKey')
+      .set('Cookie', 'cookie=yep')
+      .expect('Hello dynamicCacheKey#1', done)
+  })
+
+  it('3rd dynamic cacheKey', function (done) {
+    agent
+      .get('/hello/dynamicCacheKey')
+      .set('Cookie', 'cookie=nope')
+      .expect('Hello dynamicCacheKey#2', done)
+  })
+})


### PR DESCRIPTION
The use case is when you want to cache a page based on something other than the url in the `req` or `res` objects, a cookie for example.

Usage:

```js
function getCacheKey(req, res) {
  return req.url + '|' + req.cookies.name
}

app.get('/hello', routeCache.cacheSeconds(1, getCacheKey), (req, res) => {
  res.send('hello ' + req.cookies.name + '!')
})
```