### PR TITLE
Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ routeCache.cacheSeconds(20, function(req, res) {
 })
 ```
 
+If you return `false` the response will not be cached.
+
+```javascript
+// Only cache unauthenticated responses
+routeCache.cacheSeconds(20, function(req, res) {
+  if (res.locals.signedIn) { return false }
+
+  return req.originalUrl
+})
+```
 
 ## Delete a cached route
 ```javascript

--- a/README.md
+++ b/README.md
@@ -26,18 +26,33 @@ npm test
 
 ## How to use
 ```javascript
-
 var routeCache = require('route-cache');
 
 // cache route for 20 seconds
 app.get('/index', routeCache.cacheSeconds(20), function(req, res){
-	// do your dirty work here...
-	console.log('you will only see this every 20 seconds.');
-	res.send('this response will be cached');
+  // do your dirty work here...
+  console.log('you will only see this every 20 seconds.');
+  res.send('this response will be cached');
 });
-
-
 ```
+
+By default `req.originalUrl` is used as the cache key so every URL is cached separately.
+
+You can set a custom key by passing a second argument to `cacheSeconds`.
+
+```javascript
+routeCache.cacheSeconds(20, 'my-custom-cache-key')
+```
+
+You can set a dynamic key from the `req` and `res` objects by passing a function.
+
+```javascript
+// Cache authenticated and unauthenticated responses separately
+routeCache.cacheSeconds(20, function(req, res) {
+  return req.originalUrl + '|' + res.locals.signedIn
+})
+```
+
 
 ## Delete a cached route
 ```javascript

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ module.exports.config = function (opts) {
 module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
   var ttl = secondsTTL * 1000
   return function (req, res, next) {
-    var key = req.originalUrl
+    var key = req.originalUrl // default cache key
     if (typeof cacheKey === 'function') {
-      key = cacheKey(req, res)
+      key = cacheKey(req, res) // dynamic key
     } else if (typeof cacheKey === 'string') {
-      key = cacheKey
+      key = cacheKey // custom key
     }
 
     if (redirects[key]) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,13 @@ module.exports.config = function (opts) {
 module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
   var ttl = secondsTTL * 1000
   return function (req, res, next) {
-    var key = (cacheKey === undefined) ? req.originalUrl : cacheKey
+    var key = req.originalUrl
+    if (typeof cacheKey === 'function') {
+      key = cacheKey(req, res)
+    } else if (typeof cacheKey === 'string') {
+      key = cacheKey
+    }
+
     if (redirects[key]) {
       return res.redirect(redirects[key].status, redirects[key].url)
     }
@@ -53,8 +59,6 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
     var didHandle = false
 
     function rawSend (data, isJson) {
-      var key = (cacheKey === undefined) ? req.originalUrl : cacheKey
-
       // pass-through for Buffer - not supported
       if (typeof data === 'object') {
         if (Buffer.isBuffer(data)) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
     var key = req.originalUrl // default cache key
     if (typeof cacheKey === 'function') {
       key = cacheKey(req, res) // dynamic key
+      // Allow skipping the cache
+      if (!key) { return next() }
     } else if (typeof cacheKey === 'string') {
       key = cacheKey // custom key
     }

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
         subscriber = queues[key].shift()
         process.nextTick(subscriber)
       }
+      delete queues[key]
 
       if (isJson) {
         res.original_json(body)
@@ -109,7 +110,6 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
 
       // If response happens to be a redirect -- store it to redirect all subsequent requests.
       res.redirect = function (url) {
-        delete queues[key]
         var address = url
         var status = 302
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,15 @@ module.exports.config = function (opts) {
   return this
 }
 
+function drainQueue (key) {
+  var subscriber = null
+  while (queues[key].length > 0) {
+    subscriber = queues[key].shift()
+    process.nextTick(subscriber)
+  }
+  delete queues[key]
+}
+
 module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
   var ttl = secondsTTL * 1000
   return function (req, res, next) {
@@ -40,7 +49,6 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
     }
 
     var value = cacheStore.get(key)
-
     if (value) {
       // returns the value immediately
       if (value.isJson) {
@@ -76,14 +84,8 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
       var body = data instanceof Buffer ? data.toString() : data
       if (res.statusCode < 400) cacheStore.set(key, { body: body, isJson: isJson }, ttl)
 
-      // drain the queue so anyone else waiting for
-      // this value will get their responses.
-      var subscriber = null
-      while (queues[key].length > 0) {
-        subscriber = queues[key].shift()
-        process.nextTick(subscriber)
-      }
-      delete queues[key]
+      // send this response to everyone in the queue
+      drainQueue(key)
 
       if (isJson) {
         res.original_json(body)
@@ -127,13 +129,19 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
         }
 
         cacheStore.set('redirect:' + key, {url: address, status: status}, ttl)
-        return res.original_redirect(status, address)
+        res.original_redirect(status, address)
+        return drainQueue(key)
       }
 
       next()
     // subsequent requests will batch while the first computes
     } else {
       queues[key].push(function () {
+        var redirectKey = cacheStore.get('redirect:' + key)
+        if (redirectKey) {
+          return res.redirect(redirectKey.status, redirectKey.url)
+        }
+
         var value = cacheStore.get(key) || {}
         if (value.isJson) {
           res.json(value.body)

--- a/test/cacheKey.js
+++ b/test/cacheKey.js
@@ -17,6 +17,17 @@ app.get('/hello/dynamicCacheKey', routeCache.cacheSeconds(1, getCacheKey), funct
   res.send('Hello dynamicCacheKey#' + hitIndex)
 })
 
+function getSkippableCacheKey(req, res) {
+  if (req.query.skip) { return false }
+
+  return req.url
+}
+
+app.get('/hello/skippable', routeCache.cacheSeconds(1, getSkippableCacheKey), function (req, res) {
+  hitIndex++
+  res.send('Hello skippable#' + hitIndex)
+})
+
 var agent = request.agent(app)
 
 describe('cacheKey as a callback', function () {
@@ -40,4 +51,29 @@ describe('cacheKey as a callback', function () {
       .set('Cookie', 'cookie=nope')
       .expect('Hello dynamicCacheKey#2', done)
   })
+
+  it('should cache 1st skippable cacheKey', function (done) {
+    agent
+      .get('/hello/skippable')
+      .expect('Hello skippable#3', done)
+  })
+
+  it('should return cached 2nd skippable cacheKey', function (done) {
+    agent
+      .get('/hello/skippable')
+      .expect('Hello skippable#3', done)
+  })
+
+  it('should not cache 3rd skippable cacheKey', function (done) {
+    agent
+      .get('/hello/skippable?skip=yep')
+      .expect('Hello skippable#4', done)
+  })
+
+  it('should not cache 4th skippable cacheKey', function (done) {
+    agent
+      .get('/hello/skippable?skip=yep')
+      .expect('Hello skippable#5', done)
+  })
+
 })

--- a/test/cacheKey.js
+++ b/test/cacheKey.js
@@ -1,0 +1,43 @@
+'use strict'
+var request = require('supertest'),
+  routeCache = require('../index'),
+  express = require('express'),
+  assert = require('assert')
+
+var hitIndex = 0
+
+var app = express()
+
+function getCacheKey(req, res) {
+  return req.url + '|cookie=' + req.headers.cookie
+}
+
+app.get('/hello/dynamicCacheKey', routeCache.cacheSeconds(1, getCacheKey), function (req, res) {
+  hitIndex++
+  res.send('Hello dynamicCacheKey#' + hitIndex)
+})
+
+var agent = request.agent(app)
+
+describe('cacheKey as a callback', function () {
+  it('1st dynamic cacheKey', function (done) {
+    agent
+      .get('/hello/dynamicCacheKey')
+      .set('Cookie', 'cookie=yep')
+      .expect('Hello dynamicCacheKey#1', done)
+  })
+
+  it('2st dynamic cacheKey', function (done) {
+    agent
+      .get('/hello/dynamicCacheKey')
+      .set('Cookie', 'cookie=yep')
+      .expect('Hello dynamicCacheKey#1', done)
+  })
+
+  it('3rd dynamic cacheKey', function (done) {
+    agent
+      .get('/hello/dynamicCacheKey')
+      .set('Cookie', 'cookie=nope')
+      .expect('Hello dynamicCacheKey#2', done)
+  })
+})

--- a/test/redirects.js
+++ b/test/redirects.js
@@ -3,17 +3,11 @@ var request = require('supertest'),
   routeCache = require('../index'),
   express = require('express');
 
-var hitIndex = 0;
-
 var app = express();
 var agent = request.agent(app);
 app.use(routeCache.cacheSeconds(30));
 
 describe('res.redirect caching', function () {
-
-  app.get('/dest', function () {
-    res.send('redirect ' + hitIndex);
-  });
 
   app.get('/redirect-test', function (req, res) {
     res.redirect('/dest');


### PR DESCRIPTION
**Fixes a bug with the redirects when they were queued up**
Multiple requests to a route with slow redirects would be added to a queue but never processed so the first would get redirected but the others would just hang.  There's a test that confirms this.

**Clears keys from queues object when they're drained**

**Allows you to skip the cache by returning a falsy cacheKey**
This is useful for when you have routes that you sometimes want to cache depending on params and sometimes you don't.