### PR TITLE
Update debug to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "route-cache",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Brad Oyler <bradoyler@gmail.com> (github.com/bradoyler)",
   "license": "MIT",
   "dependencies": {
-    "debug": "3.0.1",
+    "debug": "3.1.0",
     "lru-cache": "4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Tired of

(+) 1 vulnerability found

Regular Expression Denial of Service   

Name       │ debug                                  
CVSS       │ 3.7 (Low)                              
Installed  │ 3.0.1                                  
Vulnerable │ <= 2.6.8 || >= 3.0.0 <= 3.0.1          
Patched    │ >= 2.6.9 < 3.0.0 || >= 3.1.0           
Path       │ route-cache@0.4.3 > debug@3.0.1        
More Info  │ https://nodesecurity.io/advisories/534 
