### PR TITLE
Add support for redis-backed cacheStore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,19 @@ routeCache.cacheSeconds(20, function(req, res) {
 routeCache.removeCache('/index');
 ```
 
+## Use a distributed cache
+```javascript
+const Redis = require('ioredis')
+const IoRedisStore = require('route-cache/ioRedisStore')
+
+
+const redisClient = new Redis(6379, '127.0.0.1'))
+const cacheStore = new IoRedisStore(redisClient)
+routeCache.config({cacheStore})
+```
+
 ## Future plans / todos
 - client-side Cache-Control
-- support for distributed caches (redis or memcache)
 
 ------
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const LRU = require('lru-cache')
+const LruStore = require('./lruStore')
 const debug = require('debug')('route-cache')
 const queues = Object.create(null)
 
@@ -13,13 +13,21 @@ const defaults = {
   },
   maxAge: 200 // deletes stale cache older than 200ms
 }
-let cacheStore = new LRU(defaults)
+let cacheStore = new LruStore(defaults)
 
 module.exports.config = function (opts) {
-  if (opts && opts.max) {
-    defaults.max = opts.max
+  if (opts) {
+    if (opts.max) {
+      defaults.max = opts.max
+    }
+
+    if (opts.cacheStore) {
+      cacheStore = opts.cacheStore
+    } else {
+      cacheStore = new LruStore(defaults)
+    }
+    module.exports.cacheStore = cacheStore
   }
-  cacheStore = new LRU(defaults)
   return this
 }
 
@@ -45,127 +53,143 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
       key = cacheKey // custom key
     }
 
-    const redirectKey = cacheStore.get('redirect:' + key)
-    if (redirectKey) {
-      return res.redirect(redirectKey.status, redirectKey.url)
-    }
-
-    const value = cacheStore.get(key)
-    if (value) {
-      // returns the value immediately
-      debug('hit!!', key)
-      if (value.isJson) {
-        res.json(value.body)
-      } else {
-        res.send(value.body)
+    cacheStore.get('redirect:' + key).then((redirectKey) => {
+      if (redirectKey) {
+        res.redirect(redirectKey.status, redirectKey.url)
+        return true
       }
-      return
-    }
-
-    res.original_send = res.send
-    res.original_end = res.end
-    res.original_json = res.json
-    res.original_redirect = res.redirect
-
-    if (!queues[key]) {
-      queues[key] = []
-    }
-
-    let didHandle = false
-
-    function rawSend (data, isJson) {
-      debug('rawSend', typeof data, data ? data.length : 0)
-      // pass-through for Buffer - not supported
-      if (typeof data === 'object') {
-        if (Buffer.isBuffer(data)) {
-          queues[key] = [] // clear queue
-          res.set('Content-Length', data.length)
-          res.original_send(data)
-          return
-        }
-      }
-
-      didHandle = true
-      const body = data instanceof Buffer ? data.toString() : data
-      if (res.statusCode < 400) cacheStore.set(key, { body: body, isJson: isJson }, ttl)
-
-      // send this response to everyone in the queue
-      drainQueue(key)
-
-      if (isJson) {
-        debug('res.original_json')
-        res.original_json(body)
-      } else {
-        debug('res.original_send')
-        res.original_send(body)
-      }
-    }
-
-    // first request will get rendered output
-    if (queues[key].length === 0) {
-      debug('miss:', key)
-      queues[key].push(function noop () {})
-
-      didHandle = false
-
-      res.send = function (data) {
-        // debug('res.send() >>', data.length)
-        if (didHandle) {
-          res.original_send(data)
-        } else {
-          rawSend(data, false)
-        }
-      }
-
-      res.end = (data) => {
-        res.original_end(data)
-        drainQueue(key)
-      }
-
-      res.json = function (data) {
-        rawSend(data, true)
-      }
-
-      // If response happens to be a redirect -- store it to redirect all subsequent requests.
-      res.redirect = function (url) {
-        let address = url
-        let status = 302
-
-        // allow statusCode for 301 redirect. See: https://github.com/expressjs/express/blob/master/lib/response.js#L857
-        if (arguments.length === 2) {
-          if (typeof arguments[0] === 'number') {
-            status = arguments[0]
-            address = arguments[1]
+      return false
+    }).then((handledByRedirect) => {
+      if (handledByRedirect) return true
+      return cacheStore.get(key).then((value) => {
+        if (value) {
+          // returns the value immediately
+          debug('hit!!', key)
+          if (value.isJson) {
+            res.json(value.body)
           } else {
-            console.log('res.redirect(url, status): Use res.redirect(status, url) instead')
-            status = arguments[1]
+            res.send(value.body)
+          }
+          return true
+        }
+        return false
+      })
+    }).then((handledByCache) => {
+      if (handledByCache) return true
+
+      res.original_send = res.send
+      res.original_end = res.end
+      res.original_json = res.json
+      res.original_redirect = res.redirect
+
+      if (!queues[key]) {
+        queues[key] = []
+      }
+
+      let didHandle = false
+
+      function rawSend (data, isJson) {
+        debug('rawSend', typeof data, data ? data.length : 0)
+        // pass-through for Buffer - not supported
+        if (typeof data === 'object') {
+          if (Buffer.isBuffer(data)) {
+            queues[key] = [] // clear queue
+            res.set('Content-Length', data.length)
+            res.original_send(data)
+            return
           }
         }
 
-        cacheStore.set('redirect:' + key, { url: address, status: status }, ttl)
-        res.original_redirect(status, address)
-        return drainQueue(key)
+        didHandle = true
+        const body = data instanceof Buffer ? data.toString() : data
+        if (res.statusCode < 400) cacheStore.set(key, { body: body, isJson: isJson }, ttl)
+
+        // send this response to everyone in the queue
+        drainQueue(key)
+
+        if (isJson) {
+          debug('res.original_json')
+          res.original_json(body)
+        } else {
+          debug('res.original_send')
+          res.original_send(body)
+        }
       }
 
-      next()
-    // subsequent requests will batch while the first computes
-    } else {
-      debug(key, '>> has queue.length:', queues[key].length)
-      queues[key].push(function () {
-        const redirectKey = cacheStore.get('redirect:' + key)
-        if (redirectKey) {
-          return res.redirect(redirectKey.status, redirectKey.url)
+      // first request will get rendered output
+      if (queues[key].length === 0) {
+        debug('miss:', key)
+        queues[key].push(function noop () {})
+
+        didHandle = false
+
+        res.send = function (data) {
+          // debug('res.send() >>', data.length)
+          if (didHandle) {
+            res.original_send(data)
+          } else {
+            rawSend(data, false)
+          }
         }
 
-        const value = cacheStore.get(key) || {}
-        debug('>> queued hit:', key, value.length)
-        if (value.isJson) {
-          res.json(value.body)
-        } else {
-          res.send(value.body)
+        res.end = (data) => {
+          res.original_end(data)
+          drainQueue(key)
         }
-      })
-    }
+
+        res.json = function (data) {
+          rawSend(data, true)
+        }
+
+        // If response happens to be a redirect -- store it to redirect all subsequent requests.
+        res.redirect = function (url) {
+          let address = url
+          let status = 302
+
+          // allow statusCode for 301 redirect. See: https://github.com/expressjs/express/blob/master/lib/response.js#L857
+          if (arguments.length === 2) {
+            if (typeof arguments[0] === 'number') {
+              status = arguments[0]
+              address = arguments[1]
+            } else {
+              console.log('res.redirect(url, status): Use res.redirect(status, url) instead')
+              status = arguments[1]
+            }
+          }
+
+          cacheStore.set('redirect:' + key, { url: address, status: status }, ttl)
+          res.original_redirect(status, address)
+          return drainQueue(key)
+        }
+
+        next()
+      // subsequent requests will batch while the first computes
+      } else {
+        debug(key, '>> has queue.length:', queues[key].length)
+        queues[key].push(function () {
+          cacheStore.get('redirect:' + key)
+            .then((redirectKey) => {
+              if (redirectKey) {
+                res.redirect(redirectKey.status, redirectKey.url)
+                return true
+              }
+              return false
+            })
+            .then((handledByRedirect) => {
+              if (handledByRedirect) return
+              return cacheStore.get(key).then((cachedValue) => {
+                const value = cachedValue || {}
+                debug('>> queued hit:', key, value.length)
+                if (value.isJson) {
+                  res.json(value.body)
+                } else {
+                  res.send(value.body)
+                }
+              })
+            })
+        })
+      }
+    })
   }
 }
 

--- a/ioRedisStore.js
+++ b/ioRedisStore.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const debug = require('debug')('route-cache')
+
+// This store is designed to work with https://github.com/luin/ioredis
+class IoRedisStore {
+  constructor (redisClient) {
+    this.client = redisClient
+  }
+
+  async get (key) {
+    debug('get: ' + key)
+    return this.client.get(key).then((val) => {
+      if (val === null) return val
+      return JSON.parse(val)
+    })
+  }
+
+  // Value must be a json-serializable object.
+  async set (key, value, ttlMillis) {
+    debug('set: ' + key)
+    return this.client.set(key, JSON.stringify(value), 'PX', ttlMillis)
+  }
+
+  async del (key) {
+    debug('del: ' + key)
+    return this.client.del(key)
+  }
+}
+
+module.exports = IoRedisStore

--- a/lruStore.js
+++ b/lruStore.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const LRU = require('lru-cache')
+
+// This is a simple async wrapper around lru-cache.
+class LruStore {
+  constructor (defaults) {
+    this.lru = new LRU(defaults)
+  }
+
+  async get (key) {
+    return Promise.resolve(this.lru.get(key))
+  }
+
+  async set (key, value, ttl) {
+    return Promise.resolve(this.lru.set(key, value, ttl))
+  }
+
+  async del (key) {
+    return Promise.resolve(this.lru.del(key))
+  }
+}
+
+module.exports = LruStore

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "debug": "3.1.0",
-        "lru-cache": "4.0.1"
+        "lru-cache": "4.0.1",
+        "sinon": "^14.0.0"
       },
       "devDependencies": {
         "cross-env": "^5.2.0",
@@ -191,6 +192,37 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -754,7 +786,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -1986,7 +2017,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2442,6 +2472,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2490,6 +2525,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -2740,6 +2780,31 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -3673,6 +3738,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -4066,6 +4159,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -4444,6 +4545,37 @@
           "dev": true
         }
       }
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -4878,8 +5010,7 @@
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -5807,8 +5938,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -6129,6 +6259,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -6165,6 +6300,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -6360,6 +6500,33 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -7066,6 +7233,29 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -7351,6 +7541,11 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "debug": "3.1.0",
-        "lru-cache": "4.0.1",
-        "sinon": "^14.0.0"
+        "lru-cache": "4.0.1"
       },
       "devDependencies": {
         "cross-env": "^5.2.0",
         "express": "^4.16.4",
         "mocha": "^9.1.4",
+        "sinon": "^14.0.0",
         "standard": "^16.0.4",
         "supertest": "^4.0.2"
       }
@@ -197,6 +197,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
       "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -205,6 +206,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
       "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -213,6 +215,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
       "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -222,7 +225,8 @@
     "node_modules/@sinonjs/text-encoding": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -786,6 +790,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2017,6 +2022,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2475,7 +2481,8 @@
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2529,7 +2536,8 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -2785,6 +2793,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
       "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": ">=5",
@@ -2796,12 +2805,14 @@
     "node_modules/nise/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/nise/node_modules/path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -3742,6 +3753,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
       "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^9.1.2",
@@ -3759,6 +3771,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4163,6 +4176,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4550,6 +4564,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
       "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -4558,6 +4573,7 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
       "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
@@ -4566,6 +4582,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
       "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -4575,7 +4592,8 @@
     "@sinonjs/text-encoding": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -5010,7 +5028,8 @@
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -5938,7 +5957,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -6262,7 +6282,8 @@
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -6304,7 +6325,8 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -6505,6 +6527,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
       "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": ">=5",
@@ -6516,12 +6539,14 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -7237,6 +7262,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
       "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^9.1.2",
@@ -7250,6 +7276,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -7545,7 +7572,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   "license": "MIT",
   "dependencies": {
     "debug": "3.1.0",
-    "lru-cache": "4.0.1",
-    "sinon": "^14.0.0"
+    "lru-cache": "4.0.1"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",
     "express": "^4.16.4",
     "mocha": "^9.1.4",
+    "sinon": "^14.0.0",
     "standard": "^16.0.4",
     "supertest": "^4.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "debug": "3.1.0",
-    "lru-cache": "4.0.1"
+    "lru-cache": "4.0.1",
+    "sinon": "^14.0.0"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",

--- a/test/cacheStore.js
+++ b/test/cacheStore.js
@@ -1,0 +1,70 @@
+/* globals decribe */
+'use strict'
+const assert = require('assert')
+const express = require('express')
+const request = require('supertest')
+const routeCache = require('../index')
+
+let testindex = 0
+
+class FakeStore {
+  constructor(defaults) {
+    this.store = new Map()
+  }
+
+  async get(key) {
+    return Promise.resolve(this.store.get(key))
+  }
+
+  async set(key, value, ttl) {
+    this.store.set(key, value)
+    return Promise.resolve()
+  }
+
+  async del(key) {
+    this.store.delete(key)
+    return Promise.resolve()
+  }
+}
+
+describe('# RouteCache customstore test', function () {
+  const app = express()
+  const cacheStore = new FakeStore()
+
+  app.get('/cacheStore', routeCache.cacheSeconds(1), function (req, res) {
+    testindex++
+    res.send('CacheStore ' + testindex)
+  })
+
+  app.get('/cacheStore/1', routeCache.cacheSeconds(1), function (req, res) {
+    res.send('CacheStore/1')
+  })
+
+  const agent = request.agent(app)
+
+  before(function () {
+    routeCache.config({cacheStore})
+  })
+
+  after(function () {
+    routeCache.config({})
+  })
+
+  it('1st Hello uses custom store', function (done) {
+    agent
+      .get('/cacheStore')
+      .expect(() => {
+        assert.equal(cacheStore.store.size, 1)
+      })
+      .expect('CacheStore 1', done)
+  })
+
+  it('2nd Hello uses custom store', function (done) {
+    agent
+      .get('/cacheStore')
+      .expect(() => {
+        assert.equal(cacheStore.store.size, 1)
+      })
+      .expect('CacheStore 1', done)
+  })
+})

--- a/test/ioRedisStore.js
+++ b/test/ioRedisStore.js
@@ -1,0 +1,86 @@
+/* globals decribe */
+'use strict'
+const assert = require('assert')
+const IoRedisStore = require('../ioRedisStore')
+const sinon = require("sinon")
+
+
+class FakeRedisClient {
+  constructor() {
+    this.reset()
+  }
+
+  async get(key) {
+    const result = this.store.get(key)
+    // IoRedis returns null when the key is not found.
+    return Promise.resolve(result == undefined ? null : result)
+  }
+
+  async set(key, value, ttl) {
+    this.store.set(key, value)
+    return Promise.resolve()
+  }
+
+  async del(key) {
+    this.store.delete(key)
+    return Promise.resolve()
+  }
+
+  reset() {
+    this.store = new Map()
+  }
+}
+
+describe('# ioRedisStore test', function() {
+  const fakeRedisClient = new FakeRedisClient()
+  const store = new IoRedisStore(fakeRedisClient)
+
+  afterEach(function() {
+    sinon.restore()
+    fakeRedisClient.reset()
+  })
+
+  it('returns undefined when not found', async function() {
+    assert.equal(await store.get('foo'), undefined)
+  })
+
+  it('returns cached value', async function() {
+    await store.set('foo', {value: 42})
+    assert.deepEqual(await store.get('foo'), {value: 42})
+  })
+
+  it('serializes values', async function() {
+    const setSpy = sinon.spy(fakeRedisClient, 'set')
+
+    await store.set('foo', {value: 42})
+    await store.set('foo', 42)
+
+    assert(setSpy.calledTwice)
+    assert.deepEqual(
+      setSpy.firstCall.args,
+      ['foo', '{"value":42}', 'PX', undefined]
+    )
+
+    assert.deepEqual(
+      setSpy.secondCall.args,
+      ['foo', '42', 'PX', undefined]
+    )
+  })
+
+  it('sets ttl', async function() {
+    const setSpy = sinon.spy(fakeRedisClient, 'set')
+    await store.set('foo', {value: 42}, 1200)
+
+    assert(setSpy.calledOnce)
+    assert.deepEqual(
+      setSpy.firstCall.args,
+      ['foo', '{"value":42}', 'PX', 1200])
+  })
+
+  it('deletes values', async function() {
+    await store.set('foo', {value:42})
+    assert.deepEqual(await store.get('foo'), {value:42})
+    await store.del('foo')
+    assert.deepEqual(await store.get('foo'), undefined)
+  })
+})

--- a/test/lruStore.js
+++ b/test/lruStore.js
@@ -1,0 +1,32 @@
+/* globals decribe */
+'use strict'
+const assert = require('assert')
+const LruStore = require('../lruStore')
+const LRU = require('lru-cache')
+
+describe('# LRU Store test', function() {
+  const store = new LruStore({max: 1})
+  it('returns undefined when not found', async function() {
+    assert.equal(await store.get('foo'), undefined)
+  })
+
+  it('returns cached value', async function() {
+    await store.set('foo', 42)
+    assert.equal(await store.get('foo'), 42)
+  })
+
+  it('uses passed-in arguments', async function() {
+    await store.set('foo', 42)
+    await store.set('bar', 43)
+
+    assert.equal(await store.get('foo'), undefined)
+    assert.equal(await store.get('bar'), 43)
+  })
+
+  it('deletes values', async function() {
+    await store.set('foo', 42)
+    assert.equal(await store.get('foo'), 42)
+    await store.del('foo')
+    assert.equal(await store.get('foo'), undefined)
+  })
+})


### PR DESCRIPTION
- Required making the existing lru cache store async to match
- Verified existing behavior works as-expected by running existing tests.
- Added new tests to cover custom store and the two included store implementations.
- This includes a store implementation for ioredis.
  -  It was faster in testing and had better support for redis cluster than node-redis.
  - It would be easy to follow the same pattern to enable other redis clients.
- Adds docs for how to use with ioredis. 