### PR TITLE
feat: status codes are also cached

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,9 +66,9 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
           // returns the value immediately
           debug('hit!!', key)
           if (value.isJson) {
-            res.json(value.body)
+            res.status(value.status).json(value.body)
           } else {
-            res.send(value.body)
+            res.status(value.status).send(value.body)
           }
           return true
         }
@@ -102,7 +102,7 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
 
         didHandle = true
         const body = data instanceof Buffer ? data.toString() : data
-        if (res.statusCode < 400) cacheStore.set(key, { body: body, isJson: isJson }, ttl)
+        if (res.statusCode < 400) cacheStore.set(key, { status: res.statusCode, body: body, isJson: isJson }, ttl)
 
         // send this response to everyone in the queue
         drainQueue(key)
@@ -181,9 +181,9 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
                 const value = cachedValue || {}
                 debug('>> queued hit:', key, value.length)
                 if (value.isJson) {
-                  res.json(value.body)
+                  res.status(value.status || 200).json(value.body)
                 } else {
-                  res.send(value.body)
+                  res.status(value.status || 200).send(value.body)
                 }
               })
             })

--- a/test/params.js
+++ b/test/params.js
@@ -1,9 +1,11 @@
 'use strict'
 var request = require('supertest'),
   routeCache = require('../index'),
-  express = require('express')
+  express = require('express'),
+  assert = require('assert')
 
 var paramTestIndex = 0
+var noContentIndex = 0
 
 describe('Params / Querystrings', function () {
   var app = express()
@@ -11,6 +13,11 @@ describe('Params / Querystrings', function () {
   app.get('/params', routeCache.cacheSeconds(1, '/params-test'), function (req, res) {
     paramTestIndex++
     res.send('Params test ' + paramTestIndex)
+  })
+
+  app.get('/params-204', routeCache.cacheSeconds(10, '/params-test-204'), function (req, res) {
+    noContentIndex++
+    res.status(204).send()
   })
 
   var agent = request.agent(app)
@@ -34,5 +41,32 @@ describe('Params / Querystrings', function () {
       .get('/params?a=2')
       .expect(200)
       .expect('Params test 1', done)
+  })
+
+  it('204 without params', function (done) {
+    agent
+      .get('/params-204')
+      .expect(204, () => {
+        assert.equal(noContentIndex, 1)
+        done()
+      })
+  })
+
+  it('204 with a=1', function (done) {
+    agent
+      .get('/params-204?a=1')
+      .expect(204, () => {
+        assert.equal(noContentIndex, 1)
+        done()
+      })
+  })
+
+  it('204 with a=2', function (done) {
+    agent
+      .get('/params-204?a=2')
+      .expect(204, () => {
+        assert.equal(noContentIndex, 1)
+        done()
+      })
   })
 })

--- a/test/ttls.js
+++ b/test/ttls.js
@@ -2,7 +2,8 @@
 'use strict';
 var request = require('supertest'),
   routeCache = require('../index'),
-  express = require('express');
+  express = require('express'),
+  assert = require('assert');
 
 var app = express();
 var agent = request.agent(app);
@@ -11,10 +12,16 @@ describe('TTL:', function () {
 
   context('disabled (-1)', function () {
     var hitIndex = 0;
+    var noContentIndex = 0;
 
     app.get('/cache-disabled', routeCache.cacheSeconds(-1), function (req, res) {
       hitIndex++;
       res.send('test hit#'+ hitIndex);
+    });
+
+    app.get('/cache-disabled-204', routeCache.cacheSeconds(-1), function (req, res) {
+      noContentIndex++;
+      res.status(204).send();
     });
 
     it('Should get Hit #1', function (done) {
@@ -34,14 +41,41 @@ describe('TTL:', function () {
       });
     });
 
+    it('Should noContentIndex is 1', function (done) {
+      agent
+        .get('/cache-disabled-204')
+        .expect(204, () => {
+          assert.equal(noContentIndex, 1)
+          done()
+        })
+    });
+
+    it('Should noContentIndex is 2 (after nextTick)', function (done) {
+
+      process.nextTick(function () {
+        agent
+          .get('/cache-disabled-204')
+          .expect(204, () => {
+            assert.equal(noContentIndex, 2)
+            done()
+          })
+      });
+    });
+
   })
 
   context('zero', function () {
     var hitIndex = 0;
+    var noContentIndex = 0;
 
     app.get('/cache-zero', routeCache.cacheSeconds(0), function (req, res) {
       hitIndex++;
       res.send('test hit#'+ hitIndex);
+    });
+
+    app.get('/cache-zero-204', routeCache.cacheSeconds(0), function (req, res) {
+      noContentIndex++;
+      res.status(204).send();
     });
 
     it('Should get Hit #1', function (done) {
@@ -71,15 +105,53 @@ describe('TTL:', function () {
       }, 200);
     });
 
+    it('Should noContentIndex is 1', function (done) {
+      agent
+        .get('/cache-zero-204')
+        .expect(204, () => {
+          assert.equal(noContentIndex, 1)
+          done()
+        })
+    });
+
+    it('Should noContentIndex is 1 (after nextTick)', function (done) {
+
+      process.nextTick(function () {
+        agent
+          .get('/cache-zero-204')
+          .expect(204, () => {
+            assert.equal(noContentIndex, 1)
+            done()
+          })
+      });
+    });
+
+    it('Should noContentIndex is 2 (after 200ms delay)', function (done) {
+
+      setTimeout(function () {
+        agent
+          .get('/cache-zero-204')
+          .expect(204, () => {
+            assert.equal(noContentIndex, 2)
+            done()
+          })
+      }, 200);
+    });
+
   })
 
   context('1 second:', function () {
-
     var hitIndex = 0;
+    var noContentIndex = 0;
 
     app.get('/cache-1s', routeCache.cacheSeconds(1), function (req, res) {
       hitIndex++;
       res.send('test hit#'+ hitIndex);
+    });
+
+    app.get('/cache-1s-204', routeCache.cacheSeconds(1), function (req, res) {
+      noContentIndex++;
+      res.status(204).send();
     });
 
     it('Should get Hit #1', function (done) {
@@ -106,6 +178,39 @@ describe('TTL:', function () {
           .get('/cache-1s')
           .expect(200)
           .expect('test hit#2', done);
+      }, 1300);
+    });
+
+    it('Should noContentIndex is 1', function (done) {
+      agent
+        .get('/cache-1s-204')
+        .expect(204, () => {
+          assert.equal(noContentIndex, 1)
+          done()
+        })
+    });
+
+    it('Should noContentIndex is 1 (after 200ms delay)', function (done) {
+
+      setTimeout(function () {
+        agent
+          .get('/cache-1s-204')
+          .expect(204, () => {
+            assert.equal(noContentIndex, 1)
+            done()
+          })
+      }, 300);
+    });
+
+    it('Should noContentIndex is 2 (after 1200ms delay)', function (done) {
+
+      setTimeout(function () {
+        agent
+          .get('/cache-1s-204')
+          .expect(204, () => {
+            assert.equal(noContentIndex, 2)
+            done()
+          })
       }, 1300);
     });
 


### PR DESCRIPTION
I always use this library. Thank you very much.

This ought to fix https://github.com/bradoyler/route-cache/issues/56.

The previous implementation could only return status code 200, but with this modification, the status code will also be cached when creating the cache.
I believe this will allow for a greater variety of use cases.

I would appreciate your confirmation.