### PR TITLE
feat: content-type are also cached

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
         if (value) {
           // returns the value immediately
           debug('hit!!', key)
+          if (value.contentType) res.set('Content-Type', value.contentType)
           if (value.isJson) {
             res.status(value.status).json(value.body)
           } else {
@@ -102,7 +103,7 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
 
         didHandle = true
         const body = data instanceof Buffer ? data.toString() : data
-        if (res.statusCode < 400) cacheStore.set(key, { status: res.statusCode, body: body, isJson: isJson }, ttl)
+        if (res.statusCode < 400) cacheStore.set(key, { status: res.statusCode, body: body, isJson: isJson, contentType: res.getHeader('Content-Type') }, ttl)
 
         // send this response to everyone in the queue
         drainQueue(key)
@@ -180,6 +181,7 @@ module.exports.cacheSeconds = function (secondsTTL, cacheKey) {
               return cacheStore.get(key).then((cachedValue) => {
                 const value = cachedValue || {}
                 debug('>> queued hit:', key, value.length)
+                if (value.contentType) res.set('Content-Type', value.contentType)
                 if (value.isJson) {
                   res.status(value.status || 200).json(value.body)
                 } else {

--- a/test/app-cache.js
+++ b/test/app-cache.js
@@ -6,6 +6,7 @@ var request = require('supertest'),
 
 var hitIndex = 0;
 var noContentIndex = 0;
+var contentTypeIndex = 0;
 
 var app = express();
 var agent = request.agent(app);
@@ -41,6 +42,12 @@ describe('App-level cache:', function () {
   app.get('/test-api-204', function (req, res) {
     noContentIndex++;
     res.status(204).json();
+  });
+
+  app.get('/content-type', function (req, res) {
+    contentTypeIndex++;
+    res.set('Content-Type', 'application/xml');
+    res.send('<xml><node>This is some content</node></xml>')
   });
 
   it('1st res.send', function (done) {
@@ -135,6 +142,28 @@ describe('App-level cache:', function () {
       .get('/test-api-204')
       .expect(204, () => {
         assert.equal(noContentIndex, 2)
+        done()
+      })
+  })
+
+  it('1st content-type', function (done) {
+    agent
+      .get('/content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+        done()
+      })
+  })
+
+  it('2st content-type', function (done) {
+    agent
+      .get('/content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
         done()
       })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ let testindex = 0
 let noContentIndex = 0
 let paramTestindex = 0
 let testindexRemove = 0
+let contentTypeIndex = 0
 
 describe('# RouteCache middleware test', function () {
   const app = express()
@@ -29,6 +30,12 @@ describe('# RouteCache middleware test', function () {
   app.get('/204', routeCache.cacheSeconds(10), function (req, res) {
     noContentIndex++
     res.status(204).send()
+  })
+
+  app.get('/content-type', routeCache.cacheSeconds(10), function (req, res) {
+    contentTypeIndex++
+    res.set('Content-Type', 'application/xml')
+    res.send('<xml><node>This is some content</node></xml>')
   })
 
   app.get('/500', routeCache.cacheSeconds(10), function (req, res) {
@@ -105,6 +112,28 @@ describe('# RouteCache middleware test', function () {
       .get('/204')
       .expect(204, () => {
         assert.equal(noContentIndex, 1)
+        done()
+      })
+  })
+
+  it('1st content-type', function (done) {
+    agent
+      .get('/content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+        done()
+      })
+  })
+
+  it('2st content-type', function (done) {
+    agent
+      .get('/content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
         done()
       })
   })

--- a/test/params.js
+++ b/test/params.js
@@ -6,6 +6,7 @@ var request = require('supertest'),
 
 var paramTestIndex = 0
 var noContentIndex = 0
+var contentTypeIndex = 0
 
 describe('Params / Querystrings', function () {
   var app = express()
@@ -18,6 +19,12 @@ describe('Params / Querystrings', function () {
   app.get('/params-204', routeCache.cacheSeconds(10, '/params-test-204'), function (req, res) {
     noContentIndex++
     res.status(204).send()
+  })
+
+  app.get('/params-content-type', routeCache.cacheSeconds(10, '/params-test-content-type'), function (req, res) {
+    contentTypeIndex++
+    res.set('Content-Type', 'application/xml')
+    res.send('<xml><node>This is some content</node></xml>')
   })
 
   var agent = request.agent(app)
@@ -66,6 +73,39 @@ describe('Params / Querystrings', function () {
       .get('/params-204?a=2')
       .expect(204, () => {
         assert.equal(noContentIndex, 1)
+        done()
+      })
+  })
+
+  it('content-type without params', function (done) {
+    agent
+      .get('/params-content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+        done()
+      })
+  })
+
+  it('content-type with a=1', function (done) {
+    agent
+      .get('/params-content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+        done()
+      })
+  })
+
+  it('content-type with a=2', function (done) {
+    agent
+      .get('/params-content-type')
+      .expect(200, (error, response) => {
+        assert.equal(contentTypeIndex, 1)
+        assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+        assert.equal(response.text, '<xml><node>This is some content</node></xml>')
         done()
       })
   })

--- a/test/ttls.js
+++ b/test/ttls.js
@@ -13,6 +13,7 @@ describe('TTL:', function () {
   context('disabled (-1)', function () {
     var hitIndex = 0;
     var noContentIndex = 0;
+    var contentTypeIndex = 0;
 
     app.get('/cache-disabled', routeCache.cacheSeconds(-1), function (req, res) {
       hitIndex++;
@@ -23,6 +24,12 @@ describe('TTL:', function () {
       noContentIndex++;
       res.status(204).send();
     });
+
+    app.get('/cache-disabled-content-type', routeCache.cacheSeconds(-1), function (req, res) {
+      contentTypeIndex++
+      res.set('Content-Type', 'application/xml')
+      res.send('<xml><node>This is some content</node></xml>')
+    })
 
     it('Should get Hit #1', function (done) {
       agent
@@ -62,11 +69,36 @@ describe('TTL:', function () {
       });
     });
 
+    it('Should contentTypeIndex is 1', function (done) {
+      agent
+        .get('/cache-disabled-content-type')
+        .expect(200, (error, response) => {
+          assert.equal(contentTypeIndex, 1)
+          assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+          assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+          done()
+        })
+    });
+
+    it('Should contentTypeIndex is 2 (after nextTick)', function (done) {
+
+      process.nextTick(function () {
+        agent
+          .get('/cache-disabled-content-type')
+          .expect(200, (error, response) => {
+            assert.equal(contentTypeIndex, 2)
+            assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+            assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+            done()
+          })
+      });
+    });
   })
 
   context('zero', function () {
     var hitIndex = 0;
     var noContentIndex = 0;
+    var contentTypeIndex = 0;
 
     app.get('/cache-zero', routeCache.cacheSeconds(0), function (req, res) {
       hitIndex++;
@@ -77,6 +109,12 @@ describe('TTL:', function () {
       noContentIndex++;
       res.status(204).send();
     });
+
+    app.get('/cache-zero-content-type', routeCache.cacheSeconds(0), function (req, res) {
+      contentTypeIndex++
+      res.set('Content-Type', 'application/xml')
+      res.send('<xml><node>This is some content</node></xml>')
+    })
 
     it('Should get Hit #1', function (done) {
       agent
@@ -138,11 +176,48 @@ describe('TTL:', function () {
       }, 200);
     });
 
+    it('Should contentTypeIndex is 1', function (done) {
+      agent
+        .get('/cache-zero-content-type')
+        .expect(200, (error, response) => {
+          assert.equal(contentTypeIndex, 1)
+          assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+          assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+          done()
+        })
+    });
+
+    it('Should contentTypeIndex is 1 (after nextTick)', function (done) {
+      process.nextTick(function () {
+        agent
+          .get('/cache-zero-content-type')
+          .expect(200, (error, response) => {
+            assert.equal(contentTypeIndex, 1)
+            assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+            assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+            done()
+          })
+      });
+    });
+
+    it('Should contentTypeIndex is 2 (after 200ms delay)', function (done) {
+      setTimeout(function () {
+        agent
+          .get('/cache-zero-content-type')
+          .expect(200, (error, response) => {
+            assert.equal(contentTypeIndex, 2)
+            assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+            assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+            done()
+          })
+      }, 200);
+    });
   })
 
   context('1 second:', function () {
     var hitIndex = 0;
     var noContentIndex = 0;
+    var contentTypeIndex = 0;
 
     app.get('/cache-1s', routeCache.cacheSeconds(1), function (req, res) {
       hitIndex++;
@@ -153,6 +228,12 @@ describe('TTL:', function () {
       noContentIndex++;
       res.status(204).send();
     });
+
+    app.get('/cache-1s-content-type', routeCache.cacheSeconds(1), function (req, res) {
+      contentTypeIndex++
+      res.set('Content-Type', 'application/xml')
+      res.send('<xml><node>This is some content</node></xml>')
+    })
 
     it('Should get Hit #1', function (done) {
       agent
@@ -214,6 +295,41 @@ describe('TTL:', function () {
       }, 1300);
     });
 
-  });
+    it('Should contentTypeIndex is 1', function (done) {
+      agent
+        .get('/cache-1s-content-type')
+        .expect(200, (error, response) => {
+          assert.equal(contentTypeIndex, 1)
+          assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+          assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+          done()
+        })
+    });
 
+    it('Should contentTypeIndex is 1 (after 200ms delay)', function (done) {
+      setTimeout(function () {
+        agent
+          .get('/cache-1s-content-type')
+          .expect(200, (error, response) => {
+            assert.equal(contentTypeIndex, 1)
+            assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+            assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+            done()
+          })
+      }, 200);
+    });
+
+    it('Should contentTypeIndex is 2 (after 1200ms delay)', function (done) {
+      setTimeout(function () {
+        agent
+          .get('/cache-1s-content-type')
+          .expect(200, (error, response) => {
+            assert.equal(contentTypeIndex, 2)
+            assert.equal(response.headers['content-type'], 'application/xml; charset=utf-8')
+            assert.equal(response.text, '<xml><node>This is some content</node></xml>')
+            done()
+          })
+      }, 1200);
+    });
+  });
 });


### PR DESCRIPTION
This ought to fix https://github.com/bradoyler/route-cache/issues/43.

The response header `content-type` would also be a proposal to allow caching.

I would appreciate your confirmation.