### PR TITLE
Use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/bradoyler/route-cache.git"
+    "url": "git+https://github.com/bradoyler/route-cache.git"
   },
   "keywords": [
     "middleware",


### PR DESCRIPTION
## Summary
- update package repository metadata to use the public HTTPS GitHub URL instead of SSH

## Validation
- node metadata assertion
- git diff --check
- git ls-remote https://github.com/bradoyler/route-cache.git HEAD
- pnpm install --ignore-scripts --lockfile=false --config.auto-install-peers=false --config.strict-peer-dependencies=false
- pnpm test (standard plus 107 passing tests)
- pnpm pack --dry-run